### PR TITLE
feat: Add confirmation dialog on reset

### DIFF
--- a/src/gui_frontend/app_list_view.rs
+++ b/src/gui_frontend/app_list_view.rs
@@ -1163,21 +1163,56 @@ pub fn create_main_ui(
         #[weak]
         app_stack,
         move |_, _| {
-            app_stack.set_visible_child_name("loading");
-            set_app_action_enabled(&application, "clear_all_stats_and_achievements", false);
-            app_achievements_model.remove_all();
-            app_stat_model.remove_all();
+            MainContext::default().spawn_local(clone!(
+                #[strong]
+                app_id,
+                #[strong]
+                application,
+                #[strong]
+                app_achievements_model,
+                #[strong]
+                app_stat_model,
+                #[strong]
+                action_refresh_achievements_list,
+                #[strong]
+                app_stack,
+                async move {
+                let dialog = gtk::MessageDialog::builder()
+                    .message_type(gtk::MessageType::Warning)
+                    .buttons(gtk::ButtonsType::None)
+                    .title("Reset Everything")
+                    .text("This will reset all achievements and stats for this app. Are you sure?")
+                    .build();
 
-            let app_id_copy = app_id.get().unwrap();
-            let handle = spawn_blocking(move || {
-                ResetStats {
-                    app_id: app_id_copy,
-                    achievements_too: true,
+                dialog.add_button("Cancel", gtk::ResponseType::Cancel);
+                let reset_button = dialog.add_button("Sure, reset", gtk::ResponseType::Accept);
+                reset_button.add_css_class("destructive-action");
+
+                if let Some(current_window) = application.active_window() {
+                    dialog.set_transient_for(Some(&current_window));
                 }
-                .request()
-            });
 
-            MainContext::default().spawn_local(clone!(async move {
+                let response = dialog.run_future().await;
+                dialog.close();
+
+                if response != gtk::ResponseType::Accept {
+                    return;
+                }
+
+                app_stack.set_visible_child_name("loading");
+                set_app_action_enabled(&application, "clear_all_stats_and_achievements", false);
+                app_achievements_model.remove_all();
+                app_stat_model.remove_all();
+
+                let app_id_copy = app_id.get().unwrap();
+                let handle = spawn_blocking(move || {
+                    ResetStats {
+                        app_id: app_id_copy,
+                        achievements_too: true,
+                    }
+                    .request()
+                });
+
                 let Ok(Ok(_success)) = handle.await else {
                     return app_stack.set_visible_child_name("failed");
                 };


### PR DESCRIPTION
1. Added confirmation dialog on reset.
2. Fixed icons for appimage (at least on gnome 50 it works now, before instead of some icons were default squares)