### PR TITLE
refactor: simplify empty vector initialization in adler32 test

### DIFF
--- a/src/backend/app_manager.rs
+++ b/src/backend/app_manager.rs
@@ -881,6 +881,6 @@ mod tests {
 
     #[test]
     fn test_adler32() {
-        println!("Adler null: {:08x}", adler32(&vec![]));
+        println!("Adler null: {:08x}", adler32(&[]));
     }
 }


### PR DESCRIPTION
Avoids an unnecessary empty vector allocation in `test_adler32` by passing a slice reference (`&[]`) instead of a vector reference (`&vec![]`).

This addresses the following `clippy::useless_vec` warning:
